### PR TITLE
feat: re-implement custom_formatters token data integration for D8+

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Lint Markdown files
-        run: npx markdownlint README.md
+        run: npx markdownlint-cli README.md
 
       - name: Cache Composer dependencies
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ provision:
 
 lint:
 	$(call title,Running Markdownlint)
-	npx markdownlint README.md
+	npx markdownlint-cli README.md
 	$(call title,Running PHPCS)
 	pushd "build" >/dev/null || exit 1 && vendor/bin/phpcs && popd >/dev/null || exit 1
 	$(call title,Running PHPStan)

--- a/README.md
+++ b/README.md
@@ -1,43 +1,69 @@
 # Field tokens
 
-[![Build Status](https://travis-ci.org/Decipher/field_tokens.svg)](
-https://travis-ci.org/Decipher/field_tokens)
+[![Test](https://github.com/Decipher/field_tokens/actions/workflows/test.yml/badge.svg?branch=2.0.x)](https://github.com/Decipher/field_tokens/actions/workflows/test.yml?query=branch%3A2.0.x)
+[![Coverage](https://codecov.io/gh/Decipher/field_tokens/branch/2.0.x/graph/badge.svg)](https://codecov.io/gh/Decipher/field_tokens/branch/2.0.x)
 
-The Field tokens module add two additional types of field tokens; Formatted
-fields and field properties.
+The Field tokens module adds two additional types of field tokens:
+Formatted fields and field properties.
 
-
-
-### Formatted field tokens
+## Formatted field tokens
 
 Formatted Field tokens are tokens allowing one or many field values to be
 rendered via the default or specified field formatter.
 
 The format is:
-```
+
+```text
 [PREFIX:DELTA(S):FORMATTER:FORMATTER_SETTING_KEY-FORMATTER_SETTING_VALUE:...]
 ```
 
-(e.g. **[node:field_image-formatted:0,1:image:image_style-thumbnail]**).
+e.g. `[node:field_image-formatted:0,1:image:image_style-thumbnail]`
 
+## Field property tokens
 
-
-### Field property tokens
-
-Field property tokens are tokens allowing access to field properties on one or
-many fields.
+Field property tokens are tokens allowing access to field properties on
+one or many fields.
 
 Properties are dependent on the field type.
 
 The format is:
-```
+
+```text
 [PREFIX:DELTA(S):PROPERTY]
 ```
 
-(e.g. **[node:field_image-formatted:0:entity:url]**).
+e.g. `[node:field_image-property:0:entity:url]`
 
+## Custom Formatters integration
 
+Field tokens integrates with the
+[Custom Formatters](https://www.drupal.org/project/custom_formatters) module
+via `hook_custom_formatters_token_data_alter()`, providing the token data
+context needed for the HTML + Token formatter engine.
 
-## Required modules
+When both modules are enabled, tokens like
+`[formatted_field-image:image:...]` and `[field_property:alt]` can be used
+directly in HTML + Token formatters without entity-level chaining.
 
+## Requirements
+
+- Drupal 10 or 11
+- PHP 8.2+
 - [Token](https://www.drupal.org/project/token)
+
+## Recommended modules
+
+- [Custom Formatters](https://www.drupal.org/project/custom_formatters) --
+  Provides the HTML + Token formatter engine.
+
+## Testing
+
+This project includes a Makefile and
+[Ahoy](https://ahoy-cli.readthedocs.io/) based development environment.
+
+```bash
+make build       # Build the development environment
+make provision   # Install Drupal
+make test        # Run all PHPUnit tests
+make lint        # Run PHPCS, PHPStan, Rector, and Twig CS Fixer
+```

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ directly in HTML + Token formatters without entity-level chaining.
 ## Testing
 
 This project includes a Makefile and
-[Ahoy](https://ahoy-cli.readthedocs.io/) based development environment.
+[Ahoy](https://ahoy-cli.readthedocs.io/)-based development environment.
 
 ```bash
 make build       # Build the development environment

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "source": "https://git.drupalcode.org/project/field_tokens"
     },
     "require": {
-        "php": ">=8.1"
+        "php": ">=8.2"
     },
     "require-dev": {
         "drupal/token": "^1"

--- a/field_tokens.module
+++ b/field_tokens.module
@@ -6,3 +6,27 @@
  */
 
 declare(strict_types=1);
+
+use Drupal\Core\Field\FieldItemInterface;
+
+/**
+ * Implements hook_custom_formatters_token_data_alter().
+ */
+function field_tokens_custom_formatters_token_data_alter(array &$token_data, array $context): void {
+  $item = $context['item'];
+  if (!$item instanceof FieldItemInterface) {
+    return;
+  }
+
+  $field_definition = $item->getFieldDefinition();
+  $field_type = $field_definition->getType();
+  $entity = $item->getEntity();
+
+  $token_data["formatted_field-{$field_type}"] = [$item];
+  $token_data['field_property'] = [$item];
+  $token_data['entity'] = $entity;
+  $token_data['entity_type'] = $entity->getEntityTypeId();
+  $token_data['field'] = $field_definition;
+  $token_data['field_name'] = $entity->getEntityTypeId() . '-' . $field_definition->getName();
+  $token_data[$token_data['field_name']] = [$item];
+}

--- a/tests/src/Kernel/CustomFormattersIntegrationTest.php
+++ b/tests/src/Kernel/CustomFormattersIntegrationTest.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\field_tokens\Kernel;
+
+/**
+ * Tests custom_formatters token data integration.
+ *
+ * @group field_tokens
+ */
+class CustomFormattersIntegrationTest extends FieldTokensKernelTestBase {
+
+  /**
+   * Tests that the alter adds formatted_field-{type} context.
+   */
+  public function testAlterAddsFormattedFieldContext(): void {
+    $node = $this->createNodeWithImage();
+    $item = $node->get(static::IMAGE_FIELD_NAME)[0];
+
+    $file = $node->get(static::IMAGE_FIELD_NAME)->entity;
+    $token_data = ['node' => $node, 'file' => $file];
+    $context = ['text' => '', 'item' => $item, 'delta' => 0];
+    \Drupal::moduleHandler()->alter('custom_formatters_token_data', $token_data, $context);
+
+    $this->assertArrayHasKey('formatted_field-image', $token_data);
+    $this->assertIsArray($token_data['formatted_field-image']);
+    $this->assertCount(1, $token_data['formatted_field-image']);
+  }
+
+  /**
+   * Tests that the alter adds field_property context.
+   */
+  public function testAlterAddsFieldPropertyContext(): void {
+    $node = $this->createNodeWithImage();
+    $item = $node->get(static::IMAGE_FIELD_NAME)[0];
+    $file = $node->get(static::IMAGE_FIELD_NAME)->entity;
+
+    $token_data = ['node' => $node, 'file' => $file];
+    $context = ['text' => '', 'item' => $item, 'delta' => 0];
+    \Drupal::moduleHandler()->alter('custom_formatters_token_data', $token_data, $context);
+
+    $this->assertArrayHasKey('field_property', $token_data);
+    $this->assertIsArray($token_data['field_property']);
+    $this->assertCount(1, $token_data['field_property']);
+  }
+
+  /**
+   * Tests that the alter adds entity and entity_type context.
+   */
+  public function testAlterAddsEntityContext(): void {
+    $node = $this->createNodeWithImage();
+    $item = $node->get(static::IMAGE_FIELD_NAME)[0];
+    $file = $node->get(static::IMAGE_FIELD_NAME)->entity;
+
+    $token_data = ['node' => $node, 'file' => $file];
+    $context = ['text' => '', 'item' => $item, 'delta' => 0];
+    \Drupal::moduleHandler()->alter('custom_formatters_token_data', $token_data, $context);
+
+    $this->assertSame($node, $token_data['entity']);
+    $this->assertEquals('node', $token_data['entity_type']);
+  }
+
+  /**
+   * Tests that the alter adds field definition and field_name context.
+   */
+  public function testAlterAddsFieldDefinition(): void {
+    $node = $this->createNodeWithImage();
+    $item = $node->get(static::IMAGE_FIELD_NAME)[0];
+    $field_definition = $item->getFieldDefinition();
+    $file = $node->get(static::IMAGE_FIELD_NAME)->entity;
+
+    $token_data = ['node' => $node, 'file' => $file];
+    $context = ['text' => '', 'item' => $item, 'delta' => 0];
+    \Drupal::moduleHandler()->alter('custom_formatters_token_data', $token_data, $context);
+
+    $this->assertSame($field_definition, $token_data['field']);
+    $this->assertEquals('node-field_test_image', $token_data['field_name']);
+  }
+
+  /**
+   * Tests that the alter adds field_name-keyed items for token module.
+   */
+  public function testAlterAddsFieldNameKeyedItems(): void {
+    $node = $this->createNodeWithImage();
+    $item = $node->get(static::IMAGE_FIELD_NAME)[0];
+    $file = $node->get(static::IMAGE_FIELD_NAME)->entity;
+
+    $token_data = ['node' => $node, 'file' => $file];
+    $context = ['text' => '', 'item' => $item, 'delta' => 0];
+    \Drupal::moduleHandler()->alter('custom_formatters_token_data', $token_data, $context);
+
+    $field_name_key = 'node-' . static::IMAGE_FIELD_NAME;
+    $this->assertArrayHasKey($field_name_key, $token_data);
+    $this->assertIsArray($token_data[$field_name_key]);
+  }
+
+  /**
+   * Tests that the alter does nothing for non-FieldItemInterface items.
+   */
+  public function testAlterDoesNothingForNonFieldItem(): void {
+    $token_data = ['node' => 'not_an_entity'];
+    $context = ['text' => '', 'item' => 'not_a_field_item', 'delta' => 0];
+    \Drupal::moduleHandler()->alter('custom_formatters_token_data', $token_data, $context);
+
+    $this->assertArrayNotHasKey('formatted_field-image', $token_data);
+    $this->assertArrayNotHasKey('field_property', $token_data);
+    $this->assertArrayNotHasKey('entity', $token_data);
+    $this->assertArrayNotHasKey('field', $token_data);
+  }
+
+  /**
+   * Tests that the alter works with text field types.
+   */
+  public function testAlterWorksWithTextField(): void {
+    $node = $this->createNodeWithText([['value' => 'Hello', 'format' => 'plain_text']]);
+    $item = $node->get(static::FIELD_NAME)[0];
+
+    $token_data = ['node' => $node];
+    $context = ['text' => '', 'item' => $item, 'delta' => 0];
+    \Drupal::moduleHandler()->alter('custom_formatters_token_data', $token_data, $context);
+
+    $this->assertArrayHasKey('formatted_field-text', $token_data);
+    $this->assertArrayHasKey('field_property', $token_data);
+    $this->assertEquals('text', $token_data['field']->getType());
+  }
+
+  /**
+   * Tests end-to-end token replacement using alter-provided context.
+   */
+  public function testTokenReplacementViaAlterContext(): void {
+    $node = $this->createNodeWithImage();
+    $item = $node->get(static::IMAGE_FIELD_NAME)[0];
+
+    $token_data = ['node' => $node, 'file' => $node->get(static::IMAGE_FIELD_NAME)->entity];
+    $context = ['text' => '', 'item' => $item, 'delta' => 0];
+    \Drupal::moduleHandler()->alter('custom_formatters_token_data', $token_data, $context);
+
+    $result = \Drupal::token()->replace('[field_property:alt]', $token_data, ['clear' => TRUE]);
+
+    $this->assertEquals('Test image', $result);
+  }
+
+}


### PR DESCRIPTION
## Summary
Re-implements the Drupal 7 `hook_custom_formatters_token_data_alter()` integration for D8+, enabling direct use of `[formatted_field-{type}:...]` and `[field_property:...]` tokens in Custom Formatters' HTML + Token engine.
This functionality existed in Drupal 7 (`includes/custom_formatters.inc`) but was dropped during the D8 port.
## Changes
### `field_tokens.module`
Implements `hook_custom_formatters_token_data_alter()` to inject these context keys:
| Key | Purpose |
|-----|---------|
| `formatted_field-{type}` | Field items for `[formatted_field-image:...]` tokens |
| `field_property` | Field items for `[field_property:alt]` tokens |
| `entity` | The entity being formatted |
| `entity_type` | Entity type ID string |
| `field` | FieldConfig definition |
| `field_name` | Token module compatibility key |
### Tests (`tests/src/Kernel/CustomFormattersIntegrationTest.php`)
8 new kernel tests:
- `testAlterAddsFormattedFieldContext`
- `testAlterAddsFieldPropertyContext`
- `testAlterAddsEntityContext`
- `testAlterAddsFieldDefinition`
- `testAlterAddsFieldNameKeyedItems`
- `testAlterDoesNothingForNonFieldItem`
- `testAlterWorksWithTextField`
- `testTokenReplacementViaAlterContext`
### `README.md`
- Replaced Travis CI badge with GitHub Actions + Codecov
- Added "Custom Formatters integration" section
- Added Requirements, Recommended modules, Testing sections
- Fixed markdownlint violations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced token support when Custom Formatters is enabled, exposing formatted-field and field-property tokens and field-name keyed tokens.

* **Documentation**
  * README modernized: updated badges, clarified formatted field & field property token usage, added Custom Formatters integration notes, requirements (Drupal 10/11, PHP 8.2+, Token) and testing/dev commands.

* **Tests**
  * Added integration tests validating token population and replacement.

* **Chores**
  * Bumped PHP requirement to 8.2 and updated lint/test commands.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Decipher/field_tokens/pull/4?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->