### PR TITLE
fix(#3464190): guard against null field_types in formatter definitions

### DIFF
--- a/field_tokens.tokens.inc
+++ b/field_tokens.tokens.inc
@@ -42,7 +42,7 @@ function field_tokens_token_info() {
   foreach ($field_types as $field_type_name => $field_type_info) {
     // Build tokens for each formatter of the current field type.
     foreach ($formatters as $formatter_name => $formatter_info) {
-      if (in_array($field_type_name, $formatter_info['field_types'])) {
+      if (!empty($formatter_info['field_types']) && in_array($field_type_name, $formatter_info['field_types'])) {
         $tokens["formatted_field-{$field_type_name}"][$formatter_name] = [
           'name'        => $formatter_info['label'],
           'description' => t('@label formatter.', ['@label' => $formatter_info['label']]),
@@ -279,7 +279,7 @@ function field_tokens_tokens(string $type, array $tokens, array $data, array $op
         }
       }
 
-      if (!is_null($formatter_name) && isset($formatters[$formatter_name]) && in_array($field_type['id'], $formatters[$formatter_name]['field_types'])) {
+      if (!is_null($formatter_name) && isset($formatters[$formatter_name]) && !empty($formatters[$formatter_name]['field_types']) && in_array($field_type['id'], $formatters[$formatter_name]['field_types'])) {
         $default_settings = $formatter_manager->getDefaultSettings($formatter_name);
         if (!empty($default_settings)) {
           $formatter_settings += $default_settings;

--- a/tests/src/Kernel/NullFormatterFieldTypesTest.php
+++ b/tests/src/Kernel/NullFormatterFieldTypesTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\field_tokens\Kernel;
+
+use Drupal\Core\Field\FormatterPluginManager;
+
+/**
+ * Tests that null field_types in formatter definitions don't crash token info.
+ *
+ * @group field_tokens
+ */
+class NullFormatterFieldTypesTest extends FieldTokensKernelTestBase {
+
+  /**
+   * Tests that token info handles formatter with null field_types.
+   */
+  public function testTokenInfoHandlesNullFieldTypes(): void {
+    $formatter_manager = $this->container->get('plugin.manager.field.formatter');
+    assert($formatter_manager instanceof FormatterPluginManager);
+
+    $definitions = $formatter_manager->getDefinitions();
+    $definitions['test_null_field_types'] = [
+      'id' => 'test_null_field_types',
+      'label' => 'Test Null Field Types',
+      'class' => reset($definitions)['class'],
+      'provider' => 'field_tokens',
+      'field_types' => NULL,
+    ];
+
+    $mock_manager = $this->createMock(FormatterPluginManager::class);
+    $mock_manager->method('getDefinitions')->willReturn($definitions);
+    $mock_manager->method('getDefaultSettings')->willReturn([]);
+    $mock_manager->method('getDefinition')->willReturnCallback(
+      fn(string $id) => $definitions[$id] ?? NULL,
+    );
+
+    $this->container->set('plugin.manager.field.formatter', $mock_manager);
+
+    $info = \Drupal::moduleHandler()->invoke('field_tokens', 'token_info');
+
+    $this->assertIsArray($info);
+    $this->assertArrayHasKey('types', $info);
+    $this->assertArrayHasKey('tokens', $info);
+  }
+
+  /**
+   * Tests that token info handles formatter with absent field_types.
+   */
+  public function testTokenInfoHandlesAbsentFieldTypes(): void {
+    $formatter_manager = $this->container->get('plugin.manager.field.formatter');
+    assert($formatter_manager instanceof FormatterPluginManager);
+
+    $definitions = $formatter_manager->getDefinitions();
+    $definitions['test_absent_field_types'] = [
+      'id' => 'test_absent_field_types',
+      'label' => 'Test Absent Field Types',
+      'class' => reset($definitions)['class'],
+      'provider' => 'field_tokens',
+    ];
+
+    $mock_manager = $this->createMock(FormatterPluginManager::class);
+    $mock_manager->method('getDefinitions')->willReturn($definitions);
+    $mock_manager->method('getDefaultSettings')->willReturn([]);
+    $mock_manager->method('getDefinition')->willReturnCallback(
+      fn(string $id) => $definitions[$id] ?? NULL,
+    );
+
+    $this->container->set('plugin.manager.field.formatter', $mock_manager);
+
+    $info = \Drupal::moduleHandler()->invoke('field_tokens', 'token_info');
+
+    $this->assertIsArray($info);
+    $this->assertArrayHasKey('types', $info);
+    $this->assertArrayHasKey('tokens', $info);
+  }
+
+}


### PR DESCRIPTION
## Problem
Issue [#3464190](https://www.drupal.org/project/field_tokens/issues/3464190): Some formatter plugin definitions have a null or absent `field_types` key. When `field_tokens_token_info()` iterates over formatters at `field_tokens.tokens.inc:45`, it passes this value directly to `in_array()`, which throws:
- `TypeError: in_array(): Argument #2 ($haystack) must be of type array, null given`
- `Undefined array key "field_types"`
This crashes the Token module's "Browse available tokens" browser on Drupal 10.3+ sites.
## Fix
Added `!empty()` guards before both `in_array()` calls:
- `field_tokens.tokens.inc:45` — `field_tokens_token_info()` (token info building)
- `field_tokens.tokens.inc:282` — `field_tokens_tokens()` (token replacement, defensive)
These silently skip formatters without valid `field_types` definitions, which is correct behaviour — a formatter that declares no field type applicability should not generate tokens.
## Test-first approach
1. Wrote `NullFormatterFieldTypesTest` with two kernel test cases (null + absent `field_types`)
2. **Red:** Both tests confirmed the TypeError/undefined key at line 45
3. Applied the 2-line fix
4. **Green:** All 54 kernel tests pass (550 assertions), including the new tests
## Verification
- `make test-kernel` — 54 tests, 550 assertions, OK
- `make lint` — PHPCS, PHPStan, Rector, Twig CS Fixer all clean