### PR TITLE
chore: update scaffold to 4.15.0

### DIFF
--- a/.devtools/assemble
+++ b/.devtools/assemble
@@ -114,8 +114,10 @@ PASS('Stability updated.');
 TASK('Configuring test dependencies.');
 /** @var array<string, mixed> $build_json */
 $build_json = (array) json_decode((string) file_get_contents($build_composer_json), TRUE);
-unset($build_json['require-dev']['drupal/core-dev']);// Add symfony/phpunit-bridge with a version matching Drupal core's Symfony.
-$build_json['require-dev']['symfony/phpunit-bridge'] = (int) $drupal_version_major >= 11 ? '^7 || ^8' : '~6.4';file_put_contents($build_composer_json, json_encode($build_json, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n");
+unset($build_json['require-dev']['drupal/core-dev']);
+// Add symfony/phpunit-bridge with a version matching Drupal core's Symfony.
+$build_json['require-dev']['symfony/phpunit-bridge'] = (int) $drupal_version_major >= 11 ? '^7 || ^8' : '~6.4';
+file_put_contents($build_composer_json, json_encode($build_json, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n");
 PASS('Test dependencies configured.');
 
 TASK('Merging configuration from composer.dev.json.');
@@ -168,8 +170,13 @@ PASS('Dependencies installed.');
 // them in extension's composer.json.
 TASK("Installing suggested dependencies from extension's composer.json.");
 $composer_data = (array) json_decode((string) file_get_contents('composer.json'), TRUE);
+$build_json = (array) json_decode((string) file_get_contents($build_composer_json), TRUE);
 if (isset($composer_data['suggest']) && is_array($composer_data['suggest'])) {
   foreach (array_keys($composer_data['suggest']) as $suggest) {
+    if (isset($build_json['require'][$suggest]) || isset($build_json['require-dev'][$suggest])) {
+      NOTE('Skipping %s (already in require or require-dev).', $suggest);
+      continue;
+    }
     passthru_or_fail(sprintf('composer --working-dir=build require %s', escapeshellarg((string) $suggest)));
   }
 }

--- a/.devtools/helpers.php
+++ b/.devtools/helpers.php
@@ -51,6 +51,196 @@ function getenv_default(mixed ...$vars): string {
 }
 
 /**
+ * Read variables from a dotenv-style file into an associative array.
+ *
+ * Parses lines of the form KEY=VALUE. Lines that are blank or start with
+ * '#' (after optional whitespace) are ignored. Surrounding single or double
+ * quotes around the value are stripped. Keys and values are trimmed.
+ *
+ * @param string $file
+ *   Path to the dotenv file.
+ *
+ * @return array<string, string>
+ *   Associative array of key-value pairs. Empty if the file does not exist
+ *   or contains no parseable lines.
+ */
+function dotenv_read(string $file = '.env'): array {
+  if (!file_exists($file)) {
+    return [];
+  }
+
+  $contents = file_get_contents($file);
+  if ($contents === FALSE) {
+    return [];
+  }
+
+  $vars = [];
+  foreach (preg_split('/\r\n|\r|\n/', $contents) ?: [] as $line) {
+    $trimmed = trim($line);
+    if ($trimmed === '') {
+      continue;
+    }
+    if (str_starts_with($trimmed, '#')) {
+      continue;
+    }
+
+    if (!str_contains($trimmed, '=')) {
+      continue;
+    }
+
+    [$key, $value] = explode('=', $trimmed, 2);
+    $key = trim($key);
+    $value = trim($value);
+
+    if ($key === '') {
+      continue;
+    }
+
+    if (strlen($value) >= 2) {
+      $first = $value[0];
+      $last = $value[strlen($value) - 1];
+      if (($first === '"' && $last === '"') || ($first === "'" && $last === "'")) {
+        $value = substr($value, 1, -1);
+      }
+    }
+
+    $vars[$key] = $value;
+  }
+
+  return $vars;
+}
+
+/**
+ * Set or update a variable in a dotenv-style file.
+ *
+ * If the key already exists in the file, its line is rewritten in place,
+ * preserving the order of other lines and any comments or blank lines.
+ * If the key does not exist, the assignment is appended to the end of the
+ * file. The file is created with the single assignment if it does not exist.
+ *
+ * @param string $key
+ *   Variable name to write.
+ * @param string $value
+ *   Variable value to write. Not quoted.
+ * @param string $file
+ *   Path to the dotenv file.
+ */
+function dotenv_write_var(string $key, string $value, string $file = '.env'): void {
+  $assignment = sprintf('%s=%s', $key, $value);
+
+  if (!file_exists($file)) {
+    if (file_put_contents($file, $assignment . PHP_EOL) === FALSE) {
+      FAIL('Unable to write %s', $file);
+    }
+
+    return;
+  }
+
+  $contents = file_get_contents($file);
+  if ($contents === FALSE) {
+    FAIL('Unable to read %s', $file);
+
+    // @codeCoverageIgnoreStart
+    return;
+    // @codeCoverageIgnoreEnd
+  }
+
+  $lines = preg_split('/\r\n|\r|\n/', $contents) ?: [];
+  $trailing_newline = $contents !== '' && (str_ends_with($contents, "\n") || str_ends_with($contents, "\r"));
+  if ($trailing_newline && end($lines) === '') {
+    array_pop($lines);
+  }
+
+  $replace_index = NULL;
+  foreach ($lines as $i => $line) {
+    $trimmed = trim($line);
+    if ($trimmed === '') {
+      continue;
+    }
+    if (str_starts_with($trimmed, '#')) {
+      continue;
+    }
+    if (!str_contains($trimmed, '=')) {
+      continue;
+    }
+
+    [$existing_key] = explode('=', $trimmed, 2);
+    if (trim($existing_key) === $key) {
+      $replace_index = $i;
+    }
+  }
+
+  if ($replace_index === NULL) {
+    $lines[] = $assignment;
+  }
+  else {
+    $lines[$replace_index] = $assignment;
+  }
+
+  if (file_put_contents($file, implode(PHP_EOL, $lines) . PHP_EOL) === FALSE) {
+    FAIL('Unable to write %s', $file);
+  }
+}
+
+/**
+ * Validate that a value is a TCP port in the range 1-65535.
+ *
+ * Calls FAIL() with a descriptive message if validation fails.
+ *
+ * @param string $value
+ *   The value to validate.
+ * @param string $source
+ *   Source name used in the error message (e.g. 'WEBSERVER_PORT').
+ */
+function validate_port_or_fail(string $value, string $source): void {
+  if (!ctype_digit($value) || (int) $value < 1 || (int) $value > 65535) {
+    FAIL('Invalid %s "%s". Expected integer in range 1-65535.', $source, $value);
+  }
+}
+
+/**
+ * Find a free TCP port by scanning a range of ports.
+ *
+ * Each port is probed by attempting a client connect to localhost. A
+ * connection that succeeds means some server is already listening on
+ * that port (on either IPv4 or IPv6, whichever the resolver picks).
+ * A connection that is refused means the port is free. This works on
+ * environments without IPv6 (e.g. Docker-based CI) where a server-side
+ * bind probe to [::1] would always fail. Calls FAIL() if no free port
+ * is found within $max_attempts.
+ *
+ * @param int $start
+ *   Port number to start scanning from.
+ * @param int $max_attempts
+ *   Maximum number of ports to try.
+ *
+ * @return int
+ *   The first free port found.
+ */
+function find_free_port(int $start = 8000, int $max_attempts = 100): int {
+  if ($start < 1 || $start > 65535) {
+    FAIL('Start port must be between 1 and 65535, got %d', $start);
+  }
+  if ($max_attempts < 1) {
+    FAIL('Max attempts must be a positive integer, got %d', $max_attempts);
+  }
+
+  for ($port = $start; $port < $start + $max_attempts; $port++) {
+    $conn = @stream_socket_client(sprintf('tcp://localhost:%d', $port), $errno, $errstr, 0.2);
+    if ($conn === FALSE) {
+      return $port;
+    }
+    fclose($conn);
+  }
+
+  FAIL('Unable to find a free port in range %d-%d', $start, $start + $max_attempts - 1);
+
+  // @codeCoverageIgnoreStart
+  return $start;
+  // @codeCoverageIgnoreEnd
+}
+
+/**
  * Get required environment variable with fallback support.
  */
 function getenv_required(mixed ...$vars): string {

--- a/.devtools/start
+++ b/.devtools/start
@@ -19,11 +19,32 @@ require_once __DIR__ . '/helpers.php';
 // Webserver hostname.
 $webserver_host = getenv_default('WEBSERVER_HOST', 'localhost');
 
-// Webserver port.
-$webserver_port = getenv_default('WEBSERVER_PORT', '8000');
+// Webserver port. Resolution precedence:
+// 1. WEBSERVER_PORT env var, if set.
+// 2. WEBSERVER_PORT entry in .env, if present.
+// 3. Auto-discovery via find_free_port(), persisted to .env.
+$webserver_port = getenv_default('WEBSERVER_PORT', '');
+if ($webserver_port === '') {
+  $dotenv = dotenv_read('.env');
+  if (isset($dotenv['WEBSERVER_PORT']) && $dotenv['WEBSERVER_PORT'] !== '') {
+    $webserver_port = $dotenv['WEBSERVER_PORT'];
+  }
+  else {
+    $webserver_port = (string) find_free_port();
+    dotenv_write_var('WEBSERVER_PORT', $webserver_port);
+  }
+}
+validate_port_or_fail($webserver_port, 'WEBSERVER_PORT');
 
 // Webserver wait timeout.
 $webserver_wait_timeout = (int) getenv_default('WEBSERVER_WAIT_TIMEOUT', '5');
+
+// Enable Xdebug when XdEBUG env var is set. Xdebug extension must be installed
+// and configured on host environment (php -v should show `with Xdebug`).
+// Coverage stays on pcov in test commands because xdebug.mode=debug does
+// not include "coverage", so pcov remains the active coverage driver.
+$xdebug_enabled = getenv_default('XDEBUG', '') !== '';
+$xdebug_flags = $xdebug_enabled ? ' -d xdebug.mode=debug -d xdebug.start_with_request=yes' : '';
 
 // -----------------------------------------------------------------------------
 
@@ -32,12 +53,21 @@ echo '      💻 START ENVIRONMENT     ' . PHP_EOL;
 echo '===============================' . PHP_EOL;
 echo PHP_EOL;
 
+if ($xdebug_enabled) {
+  TASK('Verifying that the Xdebug PHP extension is installed.');
+  $php_v = (string) shell_exec('php -v 2>/dev/null');
+  if (stripos($php_v, 'xdebug') === FALSE) {
+    FAIL('XDEBUG=1 is set but the Xdebug PHP extension is not installed on the host. Install it (see https://xdebug.org/docs/install) and try again.');
+  }
+  PASS('Xdebug extension is loaded.');
+}
+
 TASK('Stopping previously started services, if any.');
 @passthru(sprintf('lsof -ti:%s | xargs kill -9 2>/dev/null', escapeshellarg($webserver_port)));
 
 TASK('Starting the PHP webserver.');
-$cwd = getcwd();
-passthru(sprintf('nohup php -S %s:%s -t %s/build/web %s/build/web/.ht.router.php >/tmp/php.log 2>&1 &', $webserver_host, $webserver_port, $cwd, $cwd));
+$cwd = (string) getcwd();
+passthru(sprintf('nohup php%s -S %s:%s -t %s/build/web %s/build/web/.ht.router.php >/tmp/php.log 2>&1 &', $xdebug_flags, escapeshellarg($webserver_host), escapeshellarg($webserver_port), escapeshellarg($cwd), escapeshellarg($cwd)));
 
 NOTE('Waiting %s seconds for the server to be ready.', (string) $webserver_wait_timeout);
 sleep($webserver_wait_timeout);
@@ -68,8 +98,7 @@ echo '===============================' . PHP_EOL;
 echo PHP_EOL;
 echo 'Directory : ' . $cwd . '/build/web' . PHP_EOL;
 echo 'URL       : http://' . $webserver_host . ':' . $webserver_port . PHP_EOL;
-echo PHP_EOL;
-echo 'Re-run when you enable or disable XDebug.' . PHP_EOL;
+echo 'XDebug    : ' . ($xdebug_enabled ? 'Enabled' : 'Disabled') . PHP_EOL;
 echo PHP_EOL;
 echo '> Next steps:' . PHP_EOL;
 echo '  .devtools/provision    # Provision the website' . PHP_EOL;

--- a/.devtools/stop
+++ b/.devtools/stop
@@ -16,8 +16,16 @@ require_once __DIR__ . '/helpers.php';
 // Variables.
 // -----------------------------------------------------------------------------
 
-// Webserver port.
-$webserver_port = getenv_default('WEBSERVER_PORT', '8000');
+// Webserver port. Resolution precedence:
+// 1. WEBSERVER_PORT env var, if set.
+// 2. WEBSERVER_PORT entry in .env, if present.
+// 3. Default '8000'.
+$webserver_port = getenv_default('WEBSERVER_PORT', '');
+if ($webserver_port === '') {
+  $dotenv = dotenv_read('.env');
+  $webserver_port = (isset($dotenv['WEBSERVER_PORT']) && $dotenv['WEBSERVER_PORT'] !== '') ? $dotenv['WEBSERVER_PORT'] : '8000';
+}
+validate_port_or_fail($webserver_port, 'WEBSERVER_PORT');
 
 // -----------------------------------------------------------------------------
 
@@ -26,10 +34,10 @@ echo '      💻 STOP ENVIRONMENT      ' . PHP_EOL;
 echo '===============================' . PHP_EOL;
 echo PHP_EOL;
 
-TASK('Stopping previously started services, if any.');
+TASK('Stopping previously started services on port %s, if any.', $webserver_port);
 @passthru(sprintf('lsof -ti:%s | xargs kill -9 2>/dev/null', escapeshellarg($webserver_port)));
 sleep(1);
-PASS('Services stopped.');
+PASS('Services stopped on port %s.', $webserver_port);
 
 echo PHP_EOL;
 echo '===============================' . PHP_EOL;

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,13 @@
+/.env
 /.logs
 /build
 /composer.lock
 /node_modules
 /vendor
+
+# Ignore all Claude files by default. Custom files should be added explicitly.
+!.claude
+.claude/*
+!.claude/settings.json
+!.claude/skills/
+.claude/skills/update-consumer-drupal-extension-scaffold/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,3 +106,23 @@ Field Tokens is an optional dependency of Custom Formatters. It enables:
 - `[field_property-{field_type}:{property}]` tokens
 
 Used in the example formatter `example_html_token_image` for image field token support.
+
+## Updating the scaffold
+
+When the user asks to update this project's scaffold (e.g. "update scaffold"), fetch the update skill from GitHub into the local `.claude/skills/` directory, then invoke it:
+
+1. Create the target directory if it does not exist:
+
+   ```bash
+   mkdir -p .claude/skills/update-consumer-drupal-extension-scaffold
+   ```
+
+2. Download the skill:
+
+   ```bash
+   curl -sSL https://raw.githubusercontent.com/AlexSkrypnyk/drupal_extension_scaffold/1.x/.scaffold/skills/update-consumer-drupal-extension-scaffold/SKILL.md -o .claude/skills/update-consumer-drupal-extension-scaffold/SKILL.md
+   ```
+
+3. Invoke the `update-consumer-drupal-extension-scaffold` skill and follow its steps.
+
+The skill directory is git-ignored - it is fetched on demand and not committed to the project.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,10 @@
 SHELL=/bin/bash
+
+# Load variables from .env if present and export them to recipe shells. The
+# leading '-' on -include suppresses errors when the file does not exist.
+-include .env
+export
+
 WEBSERVER_HOST ?= localhost
 WEBSERVER_PORT ?= 8000
 
@@ -6,13 +12,14 @@ define title
 	@echo -e "\n\033[36m$(1)\033[0m"
 endef
 
-.PHONY: assemble, build, help, lint, lint-fix, login, provision, reset, selenium-start, selenium-stop, start, status, stop, test, test-functional, test-functional-javascript, test-js, test-kernel, test-unit
+.PHONY: assemble build debug debug-off debug-on help lint lint-fix login provision reset selenium-start selenium-stop start stop test test-functional test-functional-javascript test-js test-kernel test-unit
 
 help:
 	@echo "COMMANDS"
 	@echo "========"
 	@echo "build           - Build or rebuild the project."
 	@echo "assemble        - Assemble a codebase using project code and all required dependencies."
+	@echo "debug           - Enable PHP XDebug step-debugging for the development server."
 	@echo "drush           - Run Drush command."
 	@echo "lint            - Check coding standards for violations."
 	@echo "lint-fix        - Fix violations in coding standards."
@@ -41,6 +48,14 @@ start:
 stop:
 	./.devtools/stop
 
+debug:
+	@ps -o command= -p "$$(lsof -ti:$(WEBSERVER_PORT) 2>/dev/null | head -1)" 2>/dev/null | grep -q 'xdebug.mode=debug' && echo "XDebug is already enabled. Run 'make start' to disable." || \
+		(XDEBUG=1 ./.devtools/start && sleep 1 && ps -o command= -p "$$(lsof -ti:$(WEBSERVER_PORT) 2>/dev/null | head -1)" 2>/dev/null | grep -q 'xdebug.mode=debug' && echo "Enabled XDebug. Run 'make start' to disable." || (echo "Failed to enable XDebug." && exit 1))
+
+debug-on xdebug xdebug-on: debug
+
+debug-off xdebug-off: start
+
 # Allow running Drush commands with `make drush <command>`
 ifeq (drush,$(firstword $(MAKECMDGOALS)))
   DRUSH_RUN_ARGS := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
@@ -57,12 +72,10 @@ provision:
 	./.devtools/provision
 
 lint:
-	$(call title,Running Markdownlint)
-	npx markdownlint-cli README.md
 	$(call title,Running PHPCS)
 	pushd "build" >/dev/null || exit 1 && vendor/bin/phpcs && popd >/dev/null || exit 1
 	$(call title,Running PHPStan)
-	pushd "build" >/dev/null || exit 1 && vendor/bin/phpstan --memory-limit=512M && popd >/dev/null || exit 1
+	pushd "build" >/dev/null || exit 1 && vendor/bin/phpstan && popd >/dev/null || exit 1
 	$(call title,Running Rector)
 	pushd "build" >/dev/null || exit 1 && vendor/bin/rector --clear-cache --dry-run && popd >/dev/null || exit 1
 	$(call title,Running Twig CS Fixer)
@@ -82,28 +95,28 @@ lint-fix:
 
 test:
 	$(call title,Running PHPUnit)
-	pushd "build" >/dev/null || exit 1 && BROWSERTEST_OUTPUT_DIRECTORY=/tmp php -d pcov.directory=/ vendor/bin/phpunit && popd >/dev/null || exit 1
+	pushd "build" >/dev/null || exit 1 && BROWSERTEST_OUTPUT_DIRECTORY=/tmp php -d pcov.directory=.. vendor/bin/phpunit && popd >/dev/null || exit 1
 	$(call title,Running Jest)
 	pushd "build" >/dev/null || exit 1 && ([ ! -d node_modules ] || npm test) && popd >/dev/null || exit 1
 
 test-unit:
 	pushd "build" >/dev/null || exit 1 && \
-	php -d pcov.directory=/ vendor/bin/phpunit --testsuite unit && \
+	php -d pcov.directory=.. vendor/bin/phpunit --testsuite unit && \
 	popd >/dev/null || exit 1
 
 test-kernel:
 	pushd "build" >/dev/null || exit 1 && \
-	php -d pcov.directory=/ vendor/bin/phpunit --testsuite kernel && \
+	php -d pcov.directory=.. vendor/bin/phpunit --testsuite kernel && \
 	popd >/dev/null || exit 1
 
 test-functional:
 	pushd "build" >/dev/null || exit 1 && \
-	BROWSERTEST_OUTPUT_DIRECTORY=/tmp php -d pcov.directory=/ vendor/bin/phpunit --testsuite functional && \
+	BROWSERTEST_OUTPUT_DIRECTORY=/tmp php -d pcov.directory=.. vendor/bin/phpunit --testsuite functional && \
 	popd >/dev/null || exit 1
 
 test-functional-javascript: selenium-start
 	pushd "build" >/dev/null || exit 1 && \
-	BROWSERTEST_OUTPUT_DIRECTORY=/tmp php -d pcov.directory=/ vendor/bin/phpunit --testsuite functional-javascript && \
+	BROWSERTEST_OUTPUT_DIRECTORY=/tmp php -d pcov.directory=.. vendor/bin/phpunit --testsuite functional-javascript && \
 	popd >/dev/null || exit 1
 
 selenium-start:
@@ -129,9 +142,9 @@ test-js:
 	popd >/dev/null || exit 1
 
 reset:
-	killall -9 php >/dev/null 2>&1 || true && \
-	chmod -Rf 777 build > /dev/null && \
-	rm -Rf build > /dev/null || true && \
-	rm -Rf .logs > /dev/null || true
+	killall -9 php >/dev/null 2>&1 || true
+	chmod -Rf 777 build .logs > /dev/null 2>&1 || true
+	rm -Rf build > /dev/null 2>&1 || true
+	rm -Rf .logs > /dev/null 2>&1 || true
 
 .DEFAULT_GOAL := build


### PR DESCRIPTION
Updates the Drupal Extension Scaffold files from the current version to [4.15.0](https://github.com/AlexSkrypnyk/drupal_extension_scaffold/releases/tag/4.15.0).

### Changes

**`.devtools/assemble`**
- Fix mangled line formatting (`unset`/comment and ternary/`file_put_contents` on single lines)
- Skip already-installed suggested dependencies to prevent interactive Composer prompt hanging CI ([#376](https://github.com/AlexSkrypnyk/drupal_extension_scaffold/issues/376))

**`.devtools/helpers.php`**
- Add `dotenv_read()`, `dotenv_write_var()` for `.env` file support
- Add `validate_port_or_fail()` for port validation
- Add `find_free_port()` for automatic port discovery (8000-8099 range)

**`.devtools/start`**
- Port auto-discovery via `.env` with fallback to `find_free_port()`
- XDebug toggle via `XDEBUG=1` environment variable

**`.devtools/stop`**
- Port resolution from `.env` with fallback to `8000`
- Report which port was stopped

**`Makefile`**
- Load `.env` variables via `-include .env`
- Add `debug`/`debug-on`/`debug-off`/`xdebug`/`xdebug-off` targets
- Fix `pcov.directory` to use relative `..` instead of `/`

**`.gitignore`**
- Add `/.env`
- Add `.claude/*` with allowlisted exceptions for `settings.json` and `skills/`

**`AGENTS.md`**
- Add "Updating the scaffold" section with curl-on-demand skill instructions

### Verification

- Drupal 11 build + provision: passed
- Drupal 10 build + provision: passed
- 57/57 tests pass, 98% code coverage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dynamic webserver port detection with automatic free-port discovery for development environments
  * Xdebug debugging support with automatic detection and enabling

* **Documentation**
  * Updated scaffold update instructions in AGENTS.md

* **Chores**
  * Enhanced .gitignore patterns for environment files and common dependencies
  * Improved development startup and shutdown processes with clearer messaging and validation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Decipher/field_tokens/pull/10?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->