### PR TITLE
fix(#3135128): add entity_type guard and language-aware token replacement

### DIFF
--- a/field_tokens.tokens.inc
+++ b/field_tokens.tokens.inc
@@ -200,9 +200,15 @@ function field_tokens_tokens(string $type, array $tokens, array $data, array $op
   ];
 
   // Entity tokens.
-  if ($type === 'entity' && !empty($data['entity']) && $data['entity'] instanceof FieldableEntityInterface) {
-    /** @var \Drupal\Core\Entity\ContentEntityBase $entity */
+  if ($type === 'entity' && !empty($data['entity_type']) && !empty($data['entity']) && $data['entity'] instanceof FieldableEntityInterface) {
     $entity = $data['entity'];
+    if (!isset($options['langcode'])) {
+      // Set the active language in $options, so that it is passed along.
+      $options['langcode'] = $entity->language()->getId();
+    }
+    // Obtain the entity with the correct language.
+    $entity = \Drupal::service('entity.repository')->getTranslationFromContext($entity, $options['langcode']);
+
     $fields = $entity->getFieldDefinitions();
 
     /** @var \Drupal\Core\Field\FieldDefinitionInterface $field */
@@ -268,7 +274,7 @@ function field_tokens_tokens(string $type, array $tokens, array $data, array $op
                 }
 
                 // Pass through to chained field tokens.
-                $field_key = ($data['entity_type'] ?? '') . '-' . $field_name;
+                $field_key = $data['entity_type'] . '-' . $field_name;
                 $chained_data = array_merge($data, [
                   ($token_type === 'property' ? '_field_tokens_items' : $token_data_type) => $token_items,
                   'field'      => $field,

--- a/tests/src/Kernel/EntityTokenReplaceTest.php
+++ b/tests/src/Kernel/EntityTokenReplaceTest.php
@@ -311,4 +311,56 @@ class EntityTokenReplaceTest extends FieldTokensKernelTestBase {
     $this->assertStringContainsString('Gamma', (string) $result);
   }
 
+  /**
+   * Tests that entity-level tokens chain without triggering notices.
+   *
+   * Regression test for issue #3135128: "Undefined index: field_name".
+   * Ensures that field_name is always present in chained token data.
+   */
+  public function testChainedTokenDataContainsFieldName(): void {
+    $node = $this->createNodeWithText([['value' => 'Regression test', 'format' => 'plain_text']]);
+
+    // Formatted token — exercises the full chain through hook_tokens().
+    $formatted = \Drupal::token()->replace(
+      '[node:' . static::FIELD_NAME . '-formatted:0:text_default]',
+      ['node' => $node]
+    );
+    $this->assertStringContainsString('Regression test', (string) $formatted);
+
+    // Property token — exercises the property chain.
+    $property = \Drupal::token()->replace(
+      '[node:' . static::FIELD_NAME . '-property:0:value]',
+      ['node' => $node]
+    );
+    $this->assertEquals('Regression test', $property);
+
+    // Entity reference chain — exercises chained token generation where
+    // the Token module previously accessed field_name.
+    $image_node = $this->createNodeWithImage();
+    $chained = \Drupal::token()->replace(
+      '[node:' . static::IMAGE_FIELD_NAME . '-property:0:entity:fid]',
+      ['node' => $image_node]
+    );
+    $this->assertNotEquals('[node:' . static::IMAGE_FIELD_NAME . '-property:0:entity:fid]', $chained);
+  }
+
+  /**
+   * Tests that missing entity_type in data produces no replacement.
+   *
+   * Ensures the defensive guard added in the fix for #3135128 prevents
+   * processing when entity_type is absent from the token data.
+   */
+  public function testMissingEntityTypeGuard(): void {
+    $node = $this->createNodeWithText([['value' => 'Test', 'format' => 'plain_text']]);
+
+    $bubbleable = new BubbleableMetadata();
+    $tokens = [
+      static::FIELD_NAME . '-formatted:0:text_default' => '[node:' . static::FIELD_NAME . '-formatted:0:text_default]',
+    ];
+    // Entity present but entity_type missing — should not replace.
+    $result = \Drupal::moduleHandler()->invoke('field_tokens', 'tokens', ['entity', $tokens, ['entity' => $node], [], $bubbleable]);
+
+    $this->assertEmpty($result);
+  }
+
 }


### PR DESCRIPTION
## Issue

Closes #3135128

Ref: https://www.drupal.org/project/field_tokens/issues/3135128

User reported "Notice: Undefined index: field_name in token.tokens.inc" after updating the Token module. The notice originated in the Token module but was triggered by field_tokens 1.x not providing complete data when chaining tokens.

Original patches by @MykolaVeryha.

## What changed

Ports the relevant improvements from MykolaVeryha's patches to the 2.0.x rewrite:

1. **Entity type guard** — Added `!empty($data['entity_type'])` to the entity token condition. This prevents processing when `entity_type` is absent from token data, which was the root cause of the "Undefined index: field_name" notice.

2. **Language-aware token replacement** — Added `getTranslationFromContext()` so field tokens resolve against the correct entity translation instead of always using the default language.

3. **Simplified field_key** — Removed the `?? ''` null coalesce on `$data['entity_type']` since the guard now guarantees it exists.

The core `field_name` fix was already present in the 2.x rewrite (explicitly set at line 282), but these defensive improvements from the original patches were missing.

## Testing

- 20 kernel tests passing (195 assertions)
- 2 new regression tests:
  - `testChainedTokenDataContainsFieldName()` — verifies formatted, property, and entity-reference-chained tokens work without notices
  - `testMissingEntityTypeGuard()` — verifies no replacement when `entity_type` is absent
- PHPCS, PHPStan, Rector all clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Entity tokens now properly handle language context during translation and replacement.
  * Improved robustness of token replacement for edge cases in chained field tokens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->