### PR TITLE
feat(#2826615): support nested array key access in property tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,26 @@ The format is:
 
 e.g. `[node:field_image-property:0:entity:url]`
 
+### Array property access
+
+When a field property stores an array (e.g., structured data, tablefield cells),
+additional colon-separated segments after the property name traverse into the
+value using each segment as a key:
+
+```text
+[PREFIX:DELTA(S):PROPERTY:KEY:KEY:...]
+```
+
+| Example | Description |
+| ------- | ----------- |
+| `[node:field_table-property:0:value:2:1]` | Integer keys — row 2, column 1 |
+| `[node:field_data-property:0:value:key]` | String key on associative array |
+| `[node:field_data-property:0:value:0:nested]` | Multi-level nesting |
+
+Both integer and string keys are supported. Scalar leaf values (`int`, `float`,
+`bool`) are cast to string. If the resolved leaf is still an array, no output is
+produced.
+
 ## Delta specification
 
 The `DELTA(S)` position supports multiple formats for selecting which field

--- a/field_tokens.tokens.inc
+++ b/field_tokens.tokens.inc
@@ -405,15 +405,18 @@ function field_tokens_tokens(string $type, array $tokens, array $data, array $op
         elseif (isset($properties[$property])) {
           $value = $item->get($property)->getValue();
           if (!empty($args) && is_array($value)) {
-            foreach ($args as $key) {
-              if (is_array($value) && array_key_exists($key, $value)) {
-                $value = $value[$key];
+            foreach ($args as $arg) {
+              if (is_array($value) && array_key_exists($arg, $value)) {
+                $value = $value[$arg];
               }
               else {
                 $value = NULL;
                 break;
               }
             }
+          }
+          elseif (!empty($args)) {
+            $value = NULL;
           }
           if (is_string($value)) {
             $output[] = $value;

--- a/field_tokens.tokens.inc
+++ b/field_tokens.tokens.inc
@@ -404,8 +404,22 @@ function field_tokens_tokens(string $type, array $tokens, array $data, array $op
         }
         elseif (isset($properties[$property])) {
           $value = $item->get($property)->getValue();
+          if (!empty($args) && is_array($value)) {
+            foreach ($args as $key) {
+              if (is_array($value) && array_key_exists($key, $value)) {
+                $value = $value[$key];
+              }
+              else {
+                $value = NULL;
+                break;
+              }
+            }
+          }
           if (is_string($value)) {
             $output[] = $value;
+          }
+          elseif (is_scalar($value)) {
+            $output[] = (string) $value;
           }
         }
       }

--- a/tests/modules/field_tokens_test/field_tokens_test.info.yml
+++ b/tests/modules/field_tokens_test/field_tokens_test.info.yml
@@ -1,0 +1,5 @@
+name: 'Field Tokens Test'
+type: module
+description: 'Test field type with array property for Field Tokens.'
+package: Testing
+core_version_requirement: ^10.1 || ^11

--- a/tests/modules/field_tokens_test/src/Plugin/Field/FieldType/ArrayItem.php
+++ b/tests/modules/field_tokens_test/src/Plugin/Field/FieldType/ArrayItem.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\field_tokens_test\Plugin\Field\FieldType;
+
+use Drupal\Core\Field\FieldItemBase;
+use Drupal\Core\Field\FieldStorageDefinitionInterface;
+use Drupal\Core\TypedData\DataDefinition;
+
+/**
+ * Defines a field type whose main property stores an array.
+ *
+ * Used to test nested array key traversal in field property tokens.
+ *
+ * @FieldType(
+ *   id = "field_tokens_test_array",
+ *   label = @Translation("Test array field"),
+ *   category = @Translation("Field Tokens"),
+ *   default_widget = "string_textarea",
+ *   default_formatter = "string",
+ *   no_ui = TRUE,
+ * )
+ */
+class ArrayItem extends FieldItemBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function propertyDefinitions(FieldStorageDefinitionInterface $field_definition) {
+    $properties['value'] = DataDefinition::create('any')
+      ->setLabel(t('Array value'))
+      ->setDescription(t('Stores an array accessible via property token key traversal.'));
+
+    return $properties;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function schema(FieldStorageDefinitionInterface $field_definition) {
+    return [
+      'columns' => [
+        'value' => [
+          'type' => 'blob',
+          'size' => 'big',
+          'serialize' => TRUE,
+        ],
+      ],
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function isEmpty() {
+    $value = $this->get('value')->getValue();
+    return $value === NULL || $value === '' || $value === [];
+  }
+
+}

--- a/tests/src/Kernel/FieldTokensKernelTestBase.php
+++ b/tests/src/Kernel/FieldTokensKernelTestBase.php
@@ -31,6 +31,11 @@ abstract class FieldTokensKernelTestBase extends KernelTestBase {
   protected const IMAGE_FIELD_NAME = 'field_test_image';
 
   /**
+   * The array field name used in tests.
+   */
+  protected const ARRAY_FIELD_NAME = 'field_test_array';
+
+  /**
    * Modules to enable.
    *
    * @var array<string>
@@ -46,6 +51,7 @@ abstract class FieldTokensKernelTestBase extends KernelTestBase {
     'image',
     'token',
     'field_tokens',
+    'field_tokens_test',
   ];
 
   /**
@@ -93,6 +99,20 @@ abstract class FieldTokensKernelTestBase extends KernelTestBase {
       'label' => 'Test Image',
     ])->save();
 
+    FieldStorageConfig::create([
+      'field_name' => static::ARRAY_FIELD_NAME,
+      'entity_type' => 'node',
+      'type' => 'field_tokens_test_array',
+      'cardinality' => FieldStorageConfig::CARDINALITY_UNLIMITED,
+    ])->save();
+
+    FieldConfig::create([
+      'field_name' => static::ARRAY_FIELD_NAME,
+      'entity_type' => 'node',
+      'bundle' => 'page',
+      'label' => 'Test Array',
+    ])->save();
+
     EntityViewDisplay::create([
       'targetEntityType' => 'node',
       'bundle' => 'page',
@@ -121,6 +141,22 @@ abstract class FieldTokensKernelTestBase extends KernelTestBase {
       'uid' => 1,
     ]);
     $node->set(static::FIELD_NAME, $values);
+    $node->save();
+    return $node;
+  }
+
+  /**
+   * Creates a node with array field values.
+   *
+   * Each value is an item array, e.g. ['value' => ['a', 'b', 'c']].
+   */
+  protected function createNodeWithArray(array $values): Node {
+    $node = Node::create([
+      'type' => 'page',
+      'title' => $this->randomMachineName(),
+      'uid' => 1,
+    ]);
+    $node->set(static::ARRAY_FIELD_NAME, $values);
     $node->save();
     return $node;
   }

--- a/tests/src/Kernel/PropertyTokenReplaceTest.php
+++ b/tests/src/Kernel/PropertyTokenReplaceTest.php
@@ -168,7 +168,7 @@ class PropertyTokenReplaceTest extends FieldTokensKernelTestBase {
   }
 
   /**
-   * Tests image property token with wildcard.
+   * Tests property token with wildcard.
    */
   public function testPropertyImageWildcard(): void {
     $node = $this->createNodeWithMultipleImages(3);
@@ -179,6 +179,133 @@ class PropertyTokenReplaceTest extends FieldTokensKernelTestBase {
     $this->assertNotEmpty($result);
     $target_ids = explode(', ', (string) $result);
     $this->assertCount(3, $target_ids);
+  }
+
+  /**
+   * Tests array property token with a single integer key.
+   */
+  public function testPropertyTokenArrayIntegerKey(): void {
+    $node = $this->createNodeWithArray([
+      ['value' => ['a', 'b', 'c']],
+    ]);
+
+    $token = '[node:' . static::ARRAY_FIELD_NAME . '-property:0:value:1]';
+    $result = \Drupal::token()->replace($token, ['node' => $node]);
+
+    $this->assertEquals('b', $result);
+  }
+
+  /**
+   * Tests array property token with multi-level nested keys.
+   */
+  public function testPropertyTokenArrayNestedKeys(): void {
+    $node = $this->createNodeWithArray([
+      ['value' => [['a', 'b'], ['c', 'd']]],
+    ]);
+
+    $token = '[node:' . static::ARRAY_FIELD_NAME . '-property:0:value:1:0]';
+    $result = \Drupal::token()->replace($token, ['node' => $node]);
+
+    $this->assertEquals('c', $result);
+  }
+
+  /**
+   * Tests array property token with a string key.
+   */
+  public function testPropertyTokenArrayStringKey(): void {
+    $node = $this->createNodeWithArray([
+      ['value' => ['first' => 'alpha', 'second' => 'beta']],
+    ]);
+
+    $token = '[node:' . static::ARRAY_FIELD_NAME . '-property:0:value:second]';
+    $result = \Drupal::token()->replace($token, ['node' => $node]);
+
+    $this->assertEquals('beta', $result);
+  }
+
+  /**
+   * Tests array property token with a non-existent key produces no output.
+   */
+  public function testPropertyTokenArrayInvalidKey(): void {
+    $node = $this->createNodeWithArray([
+      ['value' => ['a', 'b']],
+    ]);
+
+    $token = '[node:' . static::ARRAY_FIELD_NAME . '-property:0:value:5]';
+    $result = \Drupal::token()->replace($token, ['node' => $node], ['clear' => TRUE]);
+
+    $this->assertEquals('', $result);
+  }
+
+  /**
+   * Tests array property token casts a scalar (int) leaf to string.
+   */
+  public function testPropertyTokenArrayScalarLeaf(): void {
+    $node = $this->createNodeWithArray([
+      ['value' => [42, 99]],
+    ]);
+
+    $token = '[node:' . static::ARRAY_FIELD_NAME . '-property:0:value:0]';
+    $result = \Drupal::token()->replace($token, ['node' => $node]);
+
+    $this->assertEquals('42', $result);
+  }
+
+  /**
+   * Tests array property token produces no output when the leaf is an array.
+   */
+  public function testPropertyTokenArrayLeafIsArray(): void {
+    $node = $this->createNodeWithArray([
+      ['value' => ['key' => ['nested' => 'val']]],
+    ]);
+
+    $token = '[node:' . static::ARRAY_FIELD_NAME . '-property:0:value:key]';
+    $result = \Drupal::token()->replace($token, ['node' => $node], ['clear' => TRUE]);
+
+    $this->assertEquals('', $result);
+  }
+
+  /**
+   * Tests array property token with no key segments drops array values.
+   */
+  public function testPropertyTokenArrayNoSegmentsDropped(): void {
+    $node = $this->createNodeWithArray([
+      ['value' => ['a', 'b']],
+    ]);
+
+    $token = '[node:' . static::ARRAY_FIELD_NAME . '-property:0:value]';
+    $result = \Drupal::token()->replace($token, ['node' => $node], ['clear' => TRUE]);
+
+    $this->assertEquals('', $result);
+  }
+
+  /**
+   * Tests array property token partial mismatch (string leaf, further key).
+   */
+  public function testPropertyTokenArrayPartialMismatch(): void {
+    $node = $this->createNodeWithArray([
+      ['value' => ['a', 'b']],
+    ]);
+
+    $token = '[node:' . static::ARRAY_FIELD_NAME . '-property:0:value:0:deep]';
+    $result = \Drupal::token()->replace($token, ['node' => $node], ['clear' => TRUE]);
+
+    $this->assertEquals('', $result);
+  }
+
+  /**
+   * Tests array property token across multiple items.
+   */
+  public function testPropertyTokenArrayMultipleItems(): void {
+    $node = $this->createNodeWithArray([
+      ['value' => ['first', 'second']],
+      ['value' => ['third', 'fourth']],
+    ]);
+
+    $token = '[node:' . static::ARRAY_FIELD_NAME . '-property:0,1:value:0]';
+    $result = \Drupal::token()->replace($token, ['node' => $node]);
+
+    $this->assertEquals('first, third', $result);
   }
 
 }

--- a/tests/src/Kernel/PropertyTokenReplaceTest.php
+++ b/tests/src/Kernel/PropertyTokenReplaceTest.php
@@ -308,4 +308,16 @@ class PropertyTokenReplaceTest extends FieldTokensKernelTestBase {
     $this->assertEquals('first, third', $result);
   }
 
+  /**
+   * Tests scalar property with extra args produces no output.
+   */
+  public function testPropertyTokenScalarWithExtraArgsNoOutput(): void {
+    $node = $this->createNodeWithText([['value' => 'hello', 'format' => 'plain_text']]);
+
+    $token = '[node:' . static::FIELD_NAME . '-property:0:value:extra]';
+    $result = \Drupal::token()->replace($token, ['node' => $node], ['clear' => TRUE]);
+
+    $this->assertEquals('', $result);
+  }
+
 }


### PR DESCRIPTION
## Summary
 
Adds support for traversing array property values using additional colon-separated key segments in field property tokens.
 
Previously, when a field property value was an array (e.g., tablefield cells, structured data), the token silently produced no output — only plain string values were returned. This PR enables nested array key traversal so users can access specific elements within array-valued properties.
 
Closes #2826615.
 
---
 
## Examples
 
```text
[node:field_table-property:0:value:2:1]        → row 2, column 1
[node:field_data-property:0:value:row_id]       → associative array key
[node:field_data-property:0:value:0:nested]     → multi-level nesting
```
 
Both integer and string keys are supported. Scalar leaf values (`int`, `float`, `bool`) are cast to string for output.
 
---
 
## Changes
 
- **`field_tokens.tokens.inc`** — Modified the `field_property` handler to consume remaining `$args` segments as array keys after retrieving the property value. Added scalar-to-string casting for non-string leaf values.
- **`tests/modules/field_tokens_test/`** — New test module with an `ArrayItem` field type (using `DataDefinition::create('any')`) that provides a property storing array values with static property definitions.
- **`tests/src/Kernel/PropertyTokenReplaceTest.php`** — 9 new test cases covering integer keys, nested keys, string keys, invalid keys, scalar leaf casting, array-leaf no-output, no-segment dropping, partial mismatch, and multi-item traversal.
---
 
## Backward Compatibility
 
Fully backward compatible. Existing property tokens with string values continue to work identically. Array traversal only activates when additional `$args` segments are present and the property value is an array.
 
---
 
## Test Plan
 
- `DRUPAL_VERSION=11 make test-kernel` — 21/21 `PropertyTokenReplaceTest` pass (12 existing + 9 new)
- `DRUPAL_VERSION=11 make lint` — PHPCS 16/16, PHPStan 0 errors
- Drupal.org issue updated with patch for community review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Field property tokens now support nested array traversal using additional colon-separated segments, treating each segment as a keyed lookup.
  * If the resolved path is missing, not traversable, or the final leaf is an array, the token produces no output (with clearing enabled).
  * Scalar leaf values are now rendered as strings, including when extra key arguments are provided.
* **Documentation**
  * Updated README with an “Array property access” guide and examples for integer/string keys and multi-level nesting.
* **Tests**
  * Added/expanded kernel tests to validate nested array token replacement, casting behavior, and output-clearing edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->