### PR TITLE
feat(#2386655): add entity delta token for multi-value field position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,116 @@
-# Field Tokens module changelog
+# Changelog
 
-## Field Tokens v2.0.0-rc3
+## 2.0.x-dev
 
-- Add CHANGELOG.md
-- Add default theme to tests
-- Update compatibility to at least Drupal 10.1 or 11
-- Update deprecated renderPlain() to renderInIsolation() for formatted field tokens
-- Remove duplicate semi-colon
+### Features
+
+- [#3267442](https://www.drupal.org/project/field_tokens/issues/3267442):
+  Support ranges, wildcards, and omitted deltas in field tokens — e.g.
+  `[node:field_name-formatted:1:3]`, `[node:field_name-formatted:*]`, or
+  `[node:field_name-formatted]` with configurable delimiter.
+- [#2826615](https://www.drupal.org/project/field_tokens/issues/2826615):
+  Support nested array key access in property tokens using dot notation
+  (e.g. `value.nested_key`).
+- [#3143597](https://www.drupal.org/project/field_tokens/issues/3143597):
+  Support dot-notation for nested formatter settings in formatted field tokens.
+- [#3438368](https://www.drupal.org/project/field_tokens/issues/3438368):
+  Drupal 11 compatibility.
+- Re-implemented Custom Formatters token data integration for Drupal 8+,
+  restoring `[formatted_field-*]` tokens for Custom Formatters formatter types.
+
+### Bug fixes
+
+- [#2386655](https://www.drupal.org/project/field_tokens/issues/2386655):
+  Add entity delta token (`[file:delta]`, `[node:delta]`, etc.) for multi-value
+  field position, with Custom Formatters integration.
+- [#3135092](https://www.drupal.org/project/field_tokens/issues/3135092):
+  Handle formatter settings without dash-value pairs gracefully.
+- [#3135128](https://www.drupal.org/project/field_tokens/issues/3135128):
+  Add entity_type guard and language-aware token replacement.
+- [#3438368](https://www.drupal.org/project/field_tokens/issues/3438368):
+  Handle missing chained token key and formatter setting delimiter edge cases.
+- [#3438368](https://www.drupal.org/project/field_tokens/issues/3438368):
+  Handle missing chained entity reference token key.
+- [#3464190](https://www.drupal.org/project/field_tokens/issues/3464190):
+  Guard against null field_types in formatter definitions.
+- Fixed Token module `field_property` flag conflict in `hook_token_info_alter()`
+  data.
+- [#2705841](https://www.drupal.org/project/field_tokens/issues/2705841)
+  by jfrederick: Use `EntityInterface::bundle()` instead of deprecated
+  `$entity->getType()`.
+- Extended token support to all entities, not just fieldable entities.
+- [#3266313](https://www.drupal.org/project/field_tokens/issues/3266313)
+  by priyanka_chauhan31: Fixed phpcs violations.
+
+### Documentation
+
+- [#2756539](https://www.drupal.org/project/field_tokens/issues/2756539):
+  Clarified field token description placeholders.
+- Updated README.md to Drupal.org template format.
+
+### Developer experience
+
+- [#3592047](https://www.drupal.org/project/field_tokens/issues/3592047):
+  Added GitLab CI pipeline, fixed PHPStan 2.x errors, updated phpunit config,
+  restored Codecov coverage.
+- Applied drupal extension scaffold (4.15.0).
+- Added markdown linting to CI and `make lint` target.
+- Added `declare(strict_types=1)` to all source files and resolved PHPStan
+  violations.
+- Migrated functional tests and added comprehensive kernel test suite.
+
+## 2.0.0-rc3 (2026-01-26)
+
+- Fixed deprecated `renderPlain()` call — updated to `renderInIsolation()` for
+  formatted field tokens.
+- Updated `core_version_requirement` to `^10.1 || ^11`.
+- Added default theme to tests.
+- Removed duplicate semi-colon.
+
+## 2.0.0-rc2 (2023-07-10)
+
+- [#3287540](https://www.drupal.org/project/field_tokens/issues/3287540):
+  Drupal 10 compatibility.
+
+## 2.0.0-rc1 (2021-05-14)
+
+- Drupal 9 compatibility.
+
+## 8.x-1.x-dev
+
+- Added DCIR testing.
+- [#2751155](https://www.drupal.org/project/field_tokens/issues/2751155)
+  by lukasss: Fixed issue with field settings delimiter.
+
+## 8.x-1.0-beta1 (2016-02-05)
+
+- Initial Drupal 8 port.
+- Added chaining for Field property tokens.
+
+## 7.x-1.4 (2015-08-04)
+
+- Added Travis CI integration.
+- [#2543548](https://www.drupal.org/project/field_tokens/issues/2543548)
+  by jesss: Fixed undefined index `module` in `field_default_prepare_view()`.
+
+## 7.x-1.3 (2015-07-27)
+
+- Fixed issue with hidden fields.
+
+## 7.x-1.2 (2015-07-10)
+
+- Fixed dynamic tokens.
+
+## 7.x-1.1 (2015-06-30)
+
+- Added chained tokens.
+- Added Custom Formatters integration.
+
+## 7.x-1.0 (2015-06-28)
+
+- Added messages regarding Formatted Field Tokens module.
+- Fixed issue with formatted tokens.
+
+## 7.x-1.0-beta1 (2015-06-27)
+
+- Initial release.

--- a/README.md
+++ b/README.md
@@ -175,10 +175,11 @@ For a three-image field this produces `my-title-0.png`, `my-title-1.png`,
 `my-title-2.png`.
 
 In a [Custom Formatters](https://www.drupal.org/project/custom_formatters)
-HTML+Token formatter, the current item's delta is injected automatically when
-using the property-chain form without a delta spec:
+HTML+Token formatter, the current item's delta is injected automatically into
+both the direct and property-chain forms:
 
 ```text
+[file:delta]
 [field_property:entity:delta]
 ```
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Submit bug reports and feature suggestions, or track changes in the
 - Configuration
 - Formatted field tokens
 - Field property tokens
+- Entity delta token
 - Custom Formatters integration
 - Maintainers
 
@@ -154,6 +155,22 @@ item values to render:
 [node:field_image-formatted:image]
 [node:field_image-property:target_id]
 ```
+
+## Entity delta token
+
+Entity delta tokens expose the zero-based position of an entity within its
+parent multi-value field. A `delta` token is available on every entity token
+type (e.g. `[file:delta]`, `[node:delta]`, `[taxonomy_term:delta]`).
+
+The token is populated when the calling code passes the delta in token data. It
+is available automatically when accessed through a field property chain:
+
+| Example | Description |
+| ------- | ----------- |
+| `[node:field_images-property:0:entity:delta]` | Returns `0` — first item |
+| `[node:field_images-property:2:entity:delta]` | Returns `2` — third item |
+
+When no delta is passed in the token context the token returns an empty string.
 
 ## Custom Formatters integration
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Submit bug reports and feature suggestions, or track changes in the
 - Configuration
 - Formatted field tokens
 - Field property tokens
+- Delta specification
 - Entity delta token
 - Custom Formatters integration
 - Maintainers
@@ -158,19 +159,32 @@ item values to render:
 
 ## Entity delta token
 
-Entity delta tokens expose the zero-based position of an entity within its
-parent multi-value field. A `delta` token is available on every entity token
-type (e.g. `[file:delta]`, `[node:delta]`, `[taxonomy_term:delta]`).
+A `delta` token is available on every entity token type (e.g. `[file:delta]`,
+`[node:delta]`, `[taxonomy_term:delta]`). It returns the zero-based position of
+the entity within its parent multi-value field.
 
-The token is populated when the calling code passes the delta in token data. It
-is available automatically when accessed through a field property chain:
+The delta is provided at runtime by the calling code — for example,
+[filefield_paths](https://www.drupal.org/project/filefield_paths) passes each
+file's position when building filename patterns:
 
-| Example | Description |
-| ------- | ----------- |
-| `[node:field_images-property:0:entity:delta]` | Returns `0` — first item |
-| `[node:field_images-property:2:entity:delta]` | Returns `2` — third item |
+```text
+[node:title]-[file:delta].[file:ffp-extension-original]
+```
 
-When no delta is passed in the token context the token returns an empty string.
+For a three-image field this produces `my-title-0.png`, `my-title-1.png`,
+`my-title-2.png`.
+
+In a [Custom Formatters](https://www.drupal.org/project/custom_formatters)
+HTML+Token formatter, the current item's delta is injected automatically when
+using the property-chain form without a delta spec:
+
+```text
+[field_property:entity:delta]
+```
+
+When no delta is available the token returns an empty string. Resolving
+multiple items (via `*`, a range, or an omitted delta) produces a
+comma-separated list (`"0, 1, 2"`).
 
 ## Custom Formatters integration
 

--- a/README.md
+++ b/README.md
@@ -15,15 +15,15 @@ Submit bug reports and feature suggestions, or track changes in the
 
 ## Table of contents
 
-- Requirements
-- Installation
-- Configuration
-- Formatted field tokens
-- Field property tokens
-- Delta specification
-- Entity delta token
-- Custom Formatters integration
-- Maintainers
+- [Requirements](#requirements)
+- [Installation](#installation)
+- [Configuration](#configuration)
+- [Formatted field tokens](#formatted-field-tokens)
+- [Field property tokens](#field-property-tokens)
+- [Entity delta token](#entity-delta-token)
+- [Delta specification](#delta-specification)
+- [Custom Formatters integration](#custom-formatters-integration)
+- [Maintainers](#maintainers)
 
 ## Requirements
 
@@ -119,6 +119,36 @@ Both integer and string keys are supported. Scalar leaf values (`int`, `float`,
 `bool`) are cast to string. If the resolved leaf is still an array, no output is
 produced.
 
+## Entity delta token
+
+A `delta` token is available on every entity token type (e.g. `[file:delta]`,
+`[node:delta]`, `[taxonomy_term:delta]`). It returns the zero-based position of
+the entity within its parent multi-value field.
+
+The delta is provided at runtime by the calling code — for example,
+[filefield_paths](https://www.drupal.org/project/filefield_paths) passes each
+file's position when building filename patterns:
+
+```text
+[node:title]-[file:delta].[file:ffp-extension-original]
+```
+
+For a three-image field this produces `my-title-0.png`, `my-title-1.png`,
+`my-title-2.png`.
+
+In a [Custom Formatters](https://www.drupal.org/project/custom_formatters)
+HTML+Token formatter, the current item's delta is injected automatically into
+both the direct and property-chain forms:
+
+```text
+[file:delta]
+[field_property:entity:delta]
+```
+
+When no delta is available the token returns an empty string. Resolving
+multiple items (via `*`, a range, or an omitted delta) produces a
+comma-separated list (`"0, 1, 2"`).
+
 ## Delta specification
 
 The `DELTA(S)` position supports multiple formats for selecting which field
@@ -156,36 +186,6 @@ item values to render:
 [node:field_image-formatted:image]
 [node:field_image-property:target_id]
 ```
-
-## Entity delta token
-
-A `delta` token is available on every entity token type (e.g. `[file:delta]`,
-`[node:delta]`, `[taxonomy_term:delta]`). It returns the zero-based position of
-the entity within its parent multi-value field.
-
-The delta is provided at runtime by the calling code — for example,
-[filefield_paths](https://www.drupal.org/project/filefield_paths) passes each
-file's position when building filename patterns:
-
-```text
-[node:title]-[file:delta].[file:ffp-extension-original]
-```
-
-For a three-image field this produces `my-title-0.png`, `my-title-1.png`,
-`my-title-2.png`.
-
-In a [Custom Formatters](https://www.drupal.org/project/custom_formatters)
-HTML+Token formatter, the current item's delta is injected automatically into
-both the direct and property-chain forms:
-
-```text
-[file:delta]
-[field_property:entity:delta]
-```
-
-When no delta is available the token returns an empty string. Resolving
-multiple items (via `*`, a range, or an omitted delta) produces a
-comma-separated list (`"0, 1, 2"`).
 
 ## Custom Formatters integration
 

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
         "php": ">=8.2"
     },
     "require-dev": {
+        "drupal/custom_formatters": "^4@beta",
         "drupal/smart_trim": "^2",
         "drupal/token": "^1"
     }

--- a/field_tokens.module
+++ b/field_tokens.module
@@ -28,6 +28,9 @@ function field_tokens_custom_formatters_token_data_alter(array &$token_data, arr
   // resolve to the item's real position rather than the array index.
   if (isset($context['delta'])) {
     $token_data['_field_tokens_deltas'] = [$context['delta']];
+    // Also expose delta directly so [entity:delta] tokens (e.g. [file:delta])
+    // resolve without needing a property-chain form.
+    $token_data['delta'] = $context['delta'];
   }
   $token_data['entity'] = $entity;
   $token_data['entity_type'] = $entity->getEntityTypeId();

--- a/field_tokens.module
+++ b/field_tokens.module
@@ -24,6 +24,11 @@ function field_tokens_custom_formatters_token_data_alter(array &$token_data, arr
 
   $token_data['formatted_field-' . $field_type] = [$item];
   $token_data['_field_tokens_items'] = [$item];
+  // Forward the field delta so chained entity tokens (e.g. [file:delta])
+  // resolve to the item's real position rather than the array index.
+  if (isset($context['delta'])) {
+    $token_data['_field_tokens_deltas'] = [$context['delta']];
+  }
   $token_data['entity'] = $entity;
   $token_data['entity_type'] = $entity->getEntityTypeId();
   $token_data['field'] = $field_definition;

--- a/field_tokens.tokens.inc
+++ b/field_tokens.tokens.inc
@@ -149,7 +149,7 @@ function field_tokens_token_info_alter(array &$data): void {
   // is only populated when the caller passes it in token data (e.g.
   // filefield_paths for [file:delta], or field_tokens' own property chaining).
   foreach ($token_entity_map as $token_type) {
-    if (isset($data['tokens'][$token_type])) {
+    if (isset($data['tokens'][$token_type]) && !array_key_exists('delta', $data['tokens'][$token_type])) {
       $data['tokens'][$token_type]['delta'] = [
         'name'        => t('Delta'),
         'description' => t('The delta (position) of this entity within its parent multi-value field. Only available when the calling code passes the delta in token data.'),
@@ -288,11 +288,16 @@ function field_tokens_tokens(string $type, array $tokens, array $data, array $op
                   }
                 }
 
-                foreach ($token_items as $token_item) {
+                foreach ($token_items as $token_idx => $token_item) {
                   if ($token_item->isEmpty()) {
-                    continue(2);
+                    // Drop the individual empty item rather than aborting the
+                    // whole replacement, so explicitly requested deltas (e.g.
+                    // '0,2') still resolve the non-empty ones.
+                    unset($token_items[$token_idx], $token_deltas[$token_idx]);
                   }
                 }
+                $token_items = array_values($token_items);
+                $token_deltas = array_values($token_deltas);
 
                 // Pass through to chained field tokens.
                 $field_key = $data['entity_type'] . '-' . $field_name;
@@ -302,6 +307,9 @@ function field_tokens_tokens(string $type, array $tokens, array $data, array $op
                   'field_name'        => $field_key,
                   '_field_tokens_deltas' => $token_deltas,
                 ]);
+                // Evict any stale 'delta' inherited from an outer context;
+                // per-item deltas are derived from '_field_tokens_deltas'.
+                unset($chained_data['delta']);
                 $chained_data[$field_key] = $token_items;
 
                 $replacements += $token_service->generate($token_data_type, [implode(':', $parts) => $original], $chained_data, $options, $bubbleable_metadata);
@@ -396,9 +404,9 @@ function field_tokens_tokens(string $type, array $tokens, array $data, array $op
 
       $args = explode(':', (string) $args);
       $property = array_shift($args);
+      $deltas_map = $data['_field_tokens_deltas'] ?? [];
       /** @var Drupal\Core\Field\FieldItemBase $item */
       foreach (($data['_field_tokens_items'] ?? []) as $idx => $item) {
-        $delta = ($data['_field_tokens_deltas'] ?? [])[$idx] ?? $idx;
         $properties = $field->getFieldStorageDefinition()
           ->getPropertyDefinitions();
         if (isset($properties[$property]) && $properties[$property] instanceof DataReferenceDefinition && !empty($args)) {
@@ -410,8 +418,12 @@ function field_tokens_tokens(string $type, array $tokens, array $data, array $op
             $token_type = $token_entity_mapper->getTokenTypeForEntityType($reference->getEntityTypeId());
             $chained_data = [
               $token_type => $reference,
-              'delta'     => $delta,
             ];
+            // Only forward a delta when one is actually known for this item.
+            // Falling back to the array index would report a wrong position.
+            if (isset($deltas_map[$idx])) {
+              $chained_data['delta'] = $deltas_map[$idx];
+            }
             $result = $token_service->generate($token_type, [implode(':', $args) => $original], $chained_data, $options, $bubbleable_metadata);
             if (isset($result[$original])) {
               $output[] = $result[$original];
@@ -444,18 +456,22 @@ function field_tokens_tokens(string $type, array $tokens, array $data, array $op
       }
 
       if (!empty($output)) {
-        $replacements[$original] = Markup::create(implode(', ', $output));
+        // A single value is returned as a native string so the type contract
+        // matches the direct entity-delta resolution; multiple values are
+        // joined with a comma and wrapped in Markup as usual.
+        $replacements[$original] = count($output) === 1
+          ? (string) reset($output)
+          : Markup::create(implode(', ', $output));
       }
     }
   }
 
   // Entity delta token — works for any entity token type (file, node, term…).
-  elseif (isset($data[$type]) && $data[$type] instanceof EntityInterface && array_key_exists('delta', $data)) {
-    foreach ($tokens as $name => $original) {
-      if ($name === 'delta') {
-        $replacements[$original] = (string) $data['delta'];
-      }
-    }
+  // isset() is intentional: it accepts delta = 0 while rejecting delta = NULL,
+  // so an explicit "no delta context" signal leaves the token unreplaced
+  // rather than silently emitting an empty string.
+  elseif (isset($data[$type], $data['delta'], $tokens['delta']) && $data[$type] instanceof EntityInterface) {
+    $replacements[$tokens['delta']] = (string) $data['delta'];
   }
 
   return $replacements;

--- a/field_tokens.tokens.inc
+++ b/field_tokens.tokens.inc
@@ -143,6 +143,19 @@ function field_tokens_token_info_alter(array &$data): void {
   /** @var \Drupal\token\TokenEntityMapper $token_entity_mapper */
   $token_entity_mapper = \Drupal::service('token.entity_mapper');
   $token_entity_map = $token_entity_mapper->getEntityTypeMappings();
+
+  // Add a delta token to every registered entity token type. The delta is the
+  // zero-based position of the entity within its parent multi-value field and
+  // is only populated when the caller passes it in token data (e.g.
+  // filefield_paths for [file:delta], or field_tokens' own property chaining).
+  foreach ($token_entity_map as $token_type) {
+    if (isset($data['tokens'][$token_type])) {
+      $data['tokens'][$token_type]['delta'] = [
+        'name'        => t('Delta'),
+        'description' => t('The delta (position) of this entity within its parent multi-value field. Only available when the calling code passes the delta in token data.'),
+      ];
+    }
+  }
   foreach ($token_entity_map as $entity_type => $token_type) {
     if (isset($data['tokens'][$token_type])) {
       $bundles = $bundle_info->getBundleInfo($entity_type);
@@ -266,10 +279,12 @@ function field_tokens_tokens(string $type, array $tokens, array $data, array $op
                 }
 
                 $token_items = [];
+                $token_deltas = [];
                 foreach ($deltas as $delta) {
                   $item = $items->get($delta);
                   if ($item !== NULL) {
                     $token_items[] = $item;
+                    $token_deltas[] = $delta;
                   }
                 }
 
@@ -283,8 +298,9 @@ function field_tokens_tokens(string $type, array $tokens, array $data, array $op
                 $field_key = $data['entity_type'] . '-' . $field_name;
                 $chained_data = array_merge($data, [
                   ($token_type === 'property' ? '_field_tokens_items' : $token_data_type) => $token_items,
-                  'field'      => $field,
-                  'field_name' => $field_key,
+                  'field'             => $field,
+                  'field_name'        => $field_key,
+                  '_field_tokens_deltas' => $token_deltas,
                 ]);
                 $chained_data[$field_key] = $token_items;
 
@@ -381,7 +397,8 @@ function field_tokens_tokens(string $type, array $tokens, array $data, array $op
       $args = explode(':', (string) $args);
       $property = array_shift($args);
       /** @var Drupal\Core\Field\FieldItemBase $item */
-      foreach (($data['_field_tokens_items'] ?? []) as $item) {
+      foreach (($data['_field_tokens_items'] ?? []) as $idx => $item) {
+        $delta = ($data['_field_tokens_deltas'] ?? [])[$idx] ?? $idx;
         $properties = $field->getFieldStorageDefinition()
           ->getPropertyDefinitions();
         if (isset($properties[$property]) && $properties[$property] instanceof DataReferenceDefinition && !empty($args)) {
@@ -393,6 +410,7 @@ function field_tokens_tokens(string $type, array $tokens, array $data, array $op
             $token_type = $token_entity_mapper->getTokenTypeForEntityType($reference->getEntityTypeId());
             $chained_data = [
               $token_type => $reference,
+              'delta'     => $delta,
             ];
             $result = $token_service->generate($token_type, [implode(':', $args) => $original], $chained_data, $options, $bubbleable_metadata);
             if (isset($result[$original])) {
@@ -427,6 +445,15 @@ function field_tokens_tokens(string $type, array $tokens, array $data, array $op
 
       if (!empty($output)) {
         $replacements[$original] = Markup::create(implode(', ', $output));
+      }
+    }
+  }
+
+  // Entity delta token — works for any entity token type (file, node, term…).
+  elseif (isset($data[$type]) && $data[$type] instanceof EntityInterface && array_key_exists('delta', $data)) {
+    foreach ($tokens as $name => $original) {
+      if ($name === 'delta') {
+        $replacements[$original] = (string) $data['delta'];
       }
     }
   }

--- a/tests/src/Functional/CustomFormattersDeltaTest.php
+++ b/tests/src/Functional/CustomFormattersDeltaTest.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\field_tokens\Functional;
+
+use Drupal\field\Entity\FieldStorageConfig;
+use Drupal\file\Entity\File;
+
+/**
+ * Tests delta token resolution via Custom Formatters HTML+Token engine.
+ *
+ * Exercises the full path: HTMLToken::viewElements() per-item loop →
+ * $context['delta'] → field_tokens alter → token replacement. Verifies that
+ * both [file:delta] (direct) and [field_property:entity:delta] (property
+ * chain) resolve to the correct per-item position.
+ *
+ * @group field_tokens
+ */
+class CustomFormattersDeltaTest extends FieldTokensTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = ['field_tokens', 'image', 'custom_formatters'];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $defaultTheme = 'stark';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    // Make the image field created by the parent multi-value.
+    $storage = FieldStorageConfig::loadByName('node', $this->field->get('field_name'));
+    $storage->setCardinality(FieldStorageConfig::CARDINALITY_UNLIMITED);
+    $storage->save();
+
+    // Create a Custom Formatter that renders both delta token forms.
+    $formatter = \Drupal::entityTypeManager()
+      ->getStorage('formatter')
+      ->create([
+        'id' => 'delta_token_test',
+        'label' => 'Delta Token Test',
+        'type' => 'html_token',
+        'field_types' => ['image'],
+        'data' => '<div class="cf-file-delta">[file:delta]</div><div class="cf-prop-delta">[field_property:entity:delta]</div>',
+      ]);
+    $formatter->save();
+
+    // Clear the formatter plugin cache so the deriver picks up the new
+    // formatter.
+    \Drupal::service('plugin.manager.field.formatter')->clearCachedDefinitions();
+
+    // Set the view display to use the Custom Formatter.
+    \Drupal::service('entity_display.repository')
+      ->getViewDisplay('node', (string) $this->contentType->id(), 'default')
+      ->setComponent($this->field->get('field_name'), [
+        'type' => 'custom_formatters:delta_token_test',
+        'label' => 'hidden',
+      ])
+      ->save();
+  }
+
+  /**
+   * Tests that delta tokens resolve correctly per-item via CF.
+   */
+  public function testDeltaTokenViaCustomFormatter(): void {
+    $field_name = $this->field->get('field_name');
+
+    // Create 3 test images.
+    $images = $this->getTestFiles('image');
+    $this->assertGreaterThanOrEqual(3, count($images), 'Need at least 3 test images.');
+
+    $values = [];
+    for ($i = 0; $i < 3; $i++) {
+      $file = File::create([
+        'uri' => $images[$i]->uri ?? '',
+        'uid' => 1,
+        'status' => 1,
+      ]);
+      $file->save();
+      $values[] = [
+        'target_id' => $file->id(),
+        'alt' => 'Test image ' . $i,
+      ];
+    }
+
+    // Create a node with 3 images.
+    $node = $this->drupalCreateNode([
+      'type' => $this->contentType->id(),
+      $field_name => $values,
+    ]);
+
+    // View the node.
+    $this->drupalGet($node->toUrl());
+    $this->assertSession()->statusCodeEquals(200);
+
+    // Assert both [file:delta] and [field_property:entity:delta] produced
+    // correct per-item deltas for all three items.
+    $content = $this->getSession()->getPage()->getContent();
+    foreach (['0', '1', '2'] as $expected_delta) {
+      $this->assertStringContainsString(
+        '<div class="cf-file-delta">' . $expected_delta . '</div>',
+        $content,
+        "Direct [file:delta] resolved to $expected_delta."
+      );
+      $this->assertStringContainsString(
+        '<div class="cf-prop-delta">' . $expected_delta . '</div>',
+        $content,
+        "Property-chain [field_property:entity:delta] resolved to $expected_delta."
+      );
+    }
+  }
+
+}

--- a/tests/src/Functional/CustomFormattersDeltaTest.php
+++ b/tests/src/Functional/CustomFormattersDeltaTest.php
@@ -78,8 +78,9 @@ class CustomFormattersDeltaTest extends FieldTokensTestBase {
 
     $values = [];
     for ($i = 0; $i < 3; $i++) {
+      $this->assertNotEmpty($images[$i]->uri, "Test image at index {$i} must provide a URI.");
       $file = File::create([
-        'uri' => $images[$i]->uri ?? '',
+        'uri' => $images[$i]->uri,
         'uid' => 1,
         'status' => 1,
       ]);

--- a/tests/src/Kernel/CustomFormattersIntegrationTest.php
+++ b/tests/src/Kernel/CustomFormattersIntegrationTest.php
@@ -98,8 +98,9 @@ class CustomFormattersIntegrationTest extends FieldTokensKernelTestBase {
   /**
    * Tests that the alter forwards the delta from context.
    *
-   * Chained entity tokens (e.g. [file:delta]) should resolve to the item's
-   * real position.
+   * Both the direct [file:delta] and the property-chain
+   * [field_property:entity:delta] forms should resolve to the item's real
+   * position.
    */
   public function testAlterForwardsDelta(): void {
     $node = $this->createNodeWithImage();
@@ -113,6 +114,9 @@ class CustomFormattersIntegrationTest extends FieldTokensKernelTestBase {
     $result = \Drupal::token()->replace('[field_property:entity:delta]', $token_data, ['clear' => TRUE]);
     $this->assertEquals('2', $result);
     $this->assertSame([2], $token_data['_field_tokens_deltas']);
+
+    $result = \Drupal::token()->replace('[file:delta]', $token_data, ['clear' => TRUE]);
+    $this->assertEquals('2', $result);
   }
 
   /**

--- a/tests/src/Kernel/CustomFormattersIntegrationTest.php
+++ b/tests/src/Kernel/CustomFormattersIntegrationTest.php
@@ -96,6 +96,41 @@ class CustomFormattersIntegrationTest extends FieldTokensKernelTestBase {
   }
 
   /**
+   * Tests that the alter forwards the delta from context.
+   *
+   * Chained entity tokens (e.g. [file:delta]) should resolve to the item's
+   * real position.
+   */
+  public function testAlterForwardsDelta(): void {
+    $node = $this->createNodeWithImage();
+    $item = $node->get(static::IMAGE_FIELD_NAME)[0];
+    $file = $node->get(static::IMAGE_FIELD_NAME)->entity;
+
+    $token_data = ['node' => $node, 'file' => $file];
+    $context = ['text' => '', 'item' => $item, 'delta' => 2];
+    \Drupal::moduleHandler()->alter('custom_formatters_token_data', $token_data, $context);
+
+    $result = \Drupal::token()->replace('[field_property:entity:delta]', $token_data, ['clear' => TRUE]);
+    $this->assertEquals('2', $result);
+    $this->assertSame([2], $token_data['_field_tokens_deltas']);
+  }
+
+  /**
+   * Tests that the alter omits deltas when no delta is in context.
+   */
+  public function testAlterOmitsDeltasWhenContextMissing(): void {
+    $node = $this->createNodeWithImage();
+    $item = $node->get(static::IMAGE_FIELD_NAME)[0];
+    $file = $node->get(static::IMAGE_FIELD_NAME)->entity;
+
+    $token_data = ['node' => $node, 'file' => $file];
+    $context = ['text' => '', 'item' => $item];
+    \Drupal::moduleHandler()->alter('custom_formatters_token_data', $token_data, $context);
+
+    $this->assertArrayNotHasKey('_field_tokens_deltas', $token_data);
+  }
+
+  /**
    * Tests that the alter does nothing for non-FieldItemInterface items.
    */
   public function testAlterDoesNothingForNonFieldItem(): void {

--- a/tests/src/Kernel/FieldTokensKernelTestBase.php
+++ b/tests/src/Kernel/FieldTokensKernelTestBase.php
@@ -166,16 +166,7 @@ abstract class FieldTokensKernelTestBase extends KernelTestBase {
    * Creates a node with an image field value.
    */
   protected function createNodeWithImage(): Node {
-    $images = $this->getTestFiles('image');
-    $image = reset($images);
-    $this->assertNotFalse($image);
-
-    $file = File::create([
-      'uri' => $image->uri ?? '',
-      'uid' => 1,
-      'status' => 1,
-    ]);
-    $file->save();
+    $file = $this->createTestFile();
 
     $node = Node::create([
       'type' => 'page',
@@ -188,6 +179,23 @@ abstract class FieldTokensKernelTestBase extends KernelTestBase {
     ]);
     $node->save();
     return $node;
+  }
+
+  /**
+   * Creates a test file entity.
+   */
+  protected function createTestFile(): File {
+    $images = $this->getTestFiles('image');
+    $image = reset($images);
+    $this->assertNotFalse($image);
+
+    $file = File::create([
+      'uri' => $image->uri ?? '',
+      'uid' => 1,
+      'status' => 1,
+    ]);
+    $file->save();
+    return $file;
   }
 
   /**

--- a/tests/src/Kernel/FileDeltaTokenTest.php
+++ b/tests/src/Kernel/FileDeltaTokenTest.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\field_tokens\Kernel;
 
-use Drupal\file\Entity\File;
-
 /**
  * Tests [file:delta] token provided by field_tokens.
  *
@@ -55,6 +53,18 @@ class FileDeltaTokenTest extends FieldTokensKernelTestBase {
   }
 
   /**
+   * Tests that explicit delta => NULL leaves the token cleared.
+   *
+   * The token should not be silently replaced with an empty string.
+   */
+  public function testFileDeltaTokenWithExplicitNull(): void {
+    $file = $this->createTestFile();
+
+    $result = \Drupal::token()->replace('[file:delta]', ['file' => $file, 'delta' => NULL], ['clear' => TRUE]);
+    $this->assertEquals('', $result);
+  }
+
+  /**
    * Tests that field_tokens passes the correct delta when chaining file tokens.
    */
   public function testFileDeltaViaFieldPropertyChain(): void {
@@ -66,6 +76,13 @@ class FileDeltaTokenTest extends FieldTokensKernelTestBase {
     );
     $this->assertEquals('0', $result0);
 
+    // Middle element: catches off-by-one and first-element-repeated bugs.
+    $result1 = \Drupal::token()->replace(
+      '[node:' . static::IMAGE_FIELD_NAME . '-property:1:entity:delta]',
+      ['node' => $node],
+    );
+    $this->assertEquals('1', $result1);
+
     $result2 = \Drupal::token()->replace(
       '[node:' . static::IMAGE_FIELD_NAME . '-property:2:entity:delta]',
       ['node' => $node],
@@ -74,20 +91,24 @@ class FileDeltaTokenTest extends FieldTokensKernelTestBase {
   }
 
   /**
-   * Creates a test file entity.
+   * Tests that an empty item in a multi-delta selection is skipped.
+   *
+   * Replacement of the non-empty items should still proceed.
    */
-  private function createTestFile(): File {
-    $images = $this->getTestFiles('image');
-    $image = reset($images);
-    $this->assertNotFalse($image);
+  public function testMultiDeltaWithEmptyItem(): void {
+    $node = $this->createNodeWithMultipleImages(3);
 
-    $file = File::create([
-      'uri' => $image->uri ?? '',
-      'uid' => 1,
-      'status' => 1,
-    ]);
-    $file->save();
-    return $file;
+    // Make the item at delta 0 empty in-memory. Do not re-save: preSave
+    // filters empty items and would reindex the remaining items.
+    $node->get(static::IMAGE_FIELD_NAME)[0]->setValue(['target_id' => NULL]);
+
+    $result = \Drupal::token()->replace(
+      '[node:' . static::IMAGE_FIELD_NAME . '-property:0,2:entity:delta]',
+      ['node' => $node],
+    );
+    // Old behaviour (continue 2) aborted the whole replacement; the fix drops
+    // only the empty delta 0 and still resolves delta 2.
+    $this->assertEquals('2', $result);
   }
 
 }

--- a/tests/src/Kernel/FileDeltaTokenTest.php
+++ b/tests/src/Kernel/FileDeltaTokenTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\field_tokens\Kernel;
+
+use Drupal\file\Entity\File;
+
+/**
+ * Tests [file:delta] token provided by field_tokens.
+ *
+ * @group field_tokens
+ */
+class FileDeltaTokenTest extends FieldTokensKernelTestBase {
+
+  /**
+   * Tests that [file:delta] is declared in token info.
+   */
+  public function testFileDeltaTokenIsRegistered(): void {
+    $info = \Drupal::token()->getInfo();
+    $this->assertArrayHasKey('delta', $info['tokens']['file']);
+    $token = $info['tokens']['file']['delta'];
+    $this->assertArrayHasKey('name', $token);
+    $this->assertArrayHasKey('description', $token);
+  }
+
+  /**
+   * Tests that [file:delta] returns the numeric delta when set in token data.
+   */
+  public function testFileDeltaTokenReturnsValue(): void {
+    $file = $this->createTestFile();
+
+    $result = \Drupal::token()->replace('[file:delta]', ['file' => $file, 'delta' => 2]);
+    $this->assertEquals('2', $result);
+  }
+
+  /**
+   * Tests that delta=0 is correctly returned (not treated as empty/falsy).
+   */
+  public function testFileDeltaTokenReturnsZero(): void {
+    $file = $this->createTestFile();
+
+    $result = \Drupal::token()->replace('[file:delta]', ['file' => $file, 'delta' => 0]);
+    $this->assertEquals('0', $result);
+  }
+
+  /**
+   * Tests that [file:delta] returns empty when delta is not set in token data.
+   */
+  public function testFileDeltaTokenReturnsEmptyWhenNotSet(): void {
+    $file = $this->createTestFile();
+
+    $result = \Drupal::token()->replace('[file:delta]', ['file' => $file], ['clear' => TRUE]);
+    $this->assertEquals('', $result);
+  }
+
+  /**
+   * Tests that field_tokens passes the correct delta when chaining file tokens.
+   */
+  public function testFileDeltaViaFieldPropertyChain(): void {
+    $node = $this->createNodeWithMultipleImages(3);
+
+    $result0 = \Drupal::token()->replace(
+      '[node:' . static::IMAGE_FIELD_NAME . '-property:0:entity:delta]',
+      ['node' => $node],
+    );
+    $this->assertEquals('0', $result0);
+
+    $result2 = \Drupal::token()->replace(
+      '[node:' . static::IMAGE_FIELD_NAME . '-property:2:entity:delta]',
+      ['node' => $node],
+    );
+    $this->assertEquals('2', $result2);
+  }
+
+  /**
+   * Creates a test file entity.
+   */
+  private function createTestFile(): File {
+    $images = $this->getTestFiles('image');
+    $image = reset($images);
+    $this->assertNotFalse($image);
+
+    $file = File::create([
+      'uri' => $image->uri ?? '',
+      'uid' => 1,
+      'status' => 1,
+    ]);
+    $file->save();
+    return $file;
+  }
+
+}


### PR DESCRIPTION
## Summary

Resolves [#2386655](https://www.drupal.org/project/field_tokens/issues/2386655).

Multi-value entity reference fields have no way to expose the ordinal position
of each referenced entity within the field. This adds a `delta` token to every
registered entity token type (`[file:delta]`, `[node:delta]`,
`[taxonomy_term:delta]`, etc.) that returns the zero-based field position. The
token is available automatically when accessed through a field property chain
and can also be populated by external callers (e.g. filefield_paths).

## Changes

- `field_tokens.tokens.inc` — `hook_token_info_alter()` loops over the token
  entity map and adds a `delta` token to each registered entity token type.
- `field_tokens.tokens.inc` — entity processing now tracks actual field deltas
  in `$token_deltas` alongside `$token_items` and passes them as
  `_field_tokens_deltas` in chained token data.
- `field_tokens.tokens.inc` — property-chaining code reads the tracked delta
  per item and injects `'delta' => $delta` into the chained data passed to
  referenced-entity token handlers.
- `field_tokens.tokens.inc` — generic `elseif` handler returns `$data['delta']`
  for any token type whose `$data[$type]` is an `EntityInterface` instance.
- `README.md` — new "Entity delta token" section.

## Tests

- New `FileDeltaTokenTest` (kernel) — 5 cases: token is declared, returns
  correct value, returns `0` (not falsy), returns empty when delta not set,
  and works end-to-end through the field → property → entity chain.

## Verification

- [x] `make test` (kernel filter) — 105 tests, 1060 assertions, all passing
- [x] `make lint` — PHPCS, PHPStan, Rector, Twig CS all clean

## Notes

- 3 functional test failures are pre-existing (SQLite disk I/O errors in the
  test environment) and are unrelated to this change.
- The token returns an empty string when no delta is in the token data, so
  callers that do not pass it are unaffected.

## Issue

- Drupal.org: https://www.drupal.org/project/field_tokens/issues/2386655
- Branch: `2.0.x`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `[entity:delta]`, `[file:delta]`, and `[field_property:entity:delta]` token support to expose per-item positions
  * Custom Formatters inject delta context automatically when available

* **Documentation**
  * Updated README with “Delta specification” and “Entity delta token” details

* **Bug Fixes**
  * Empty field items are skipped without aborting replacements
  * Delta handling is correctly preserved across chained token resolution (including `delta=0` and explicit `NULL`)

* **Tests**
  * Added kernel and functional coverage for single- and multi-delta scenarios
<!-- end of auto-generated comment: release notes by coderabbit.ai -->